### PR TITLE
[Fix] stream lambda handler 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,10 +139,14 @@ tasks.named('test') {
 
 tasks.register('buildZip', Zip) {
 	dependsOn bootJar
+	from {
+		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+	}
 	from compileJava
 	from processResources
 	from bootJar.archiveFile.map { zipTree(it) }
 	destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+	archiveFileName.set("news-feed-0.0.1-SNAPSHOT.zip")
 }
 
 if (project.hasProperty('docker')) {


### PR DESCRIPTION
build.gradle에서 빌드 시 runtime class 포함하게 설정 및 serverless.yml 경로 수정